### PR TITLE
Category collections

### DIFF
--- a/site/templates/includes/molecules/clients.hbs
+++ b/site/templates/includes/molecules/clients.hbs
@@ -1,0 +1,14 @@
+<div id="clients">
+  {{#category "client"}}
+  <div>
+    <figure>
+    {{#markdown}}{{data.description}}{{/markdown}}
+      <figcaption>
+        <cite>
+          <small>{{data.title}}</small>
+        </cite>
+      </figcaption>
+    </figure>
+  </div>
+  {{/category}}
+</div>

--- a/site/templates/layouts/default.hbs
+++ b/site/templates/layouts/default.hbs
@@ -1,5 +1,5 @@
 <!doctype html>
-<html 
+<html
 {{#is 'casestudy' this.basename}}
 class="case"
 {{/is}}
@@ -64,7 +64,7 @@ class="landing"
   {{/any}}
 
   {{> jquery}}
-  
+
   <!-- build:js js/src/site.min.js -->
   <script src="js/lib/ffobserver.js"></script>
   <script src="js/src/ffobserver.js"></script>

--- a/site/templates/pages/index.hbs
+++ b/site/templates/pages/index.hbs
@@ -26,3 +26,6 @@ description: A design and development company based in Buffalo, New York using t
 <p>Does your team or your business have a need to discuss a subject with someone more knowledgeable? Helping to ensure you have the best access to the right answer’s where the help begins. <a href="#">Get In Touch</a></p>
 
 {{> quotes}}
+
+<h4>Clients</h4>
+{{> clients}}

--- a/site/templates/pages/polyon.hbs
+++ b/site/templates/pages/polyon.hbs
@@ -2,7 +2,8 @@
 basename: casestudy
 title: Polyon
 layout: default
-description:
+description: |
+  Jonno Riekwel of Polyon enthusiastically approached Gray Ghost Visuals with a vision to develop and construct a vector animation sequence involving the Polyon logo wonderfully crafted by Jord Riekwel.  Polyon requested that each polygon element animate indenpendently and in a staggered fashion in a desired sequence.
 categories: client
 ---
 


### PR DESCRIPTION
-  Build collection of `categories` based on `categories` property in page front-matter
- `category` helper to iterate over the pages for a specified category (see `clients.hbs` for an example)
- Move layout, data, and partial loading inside the `assemble` task so those files are reloaded when `watch` is triggered.
- We're still working on making this easier and the permalinks thing that you'd like will come then. For now, you could move template's into sub folders to build the URL structure you're looking for. I can update it when we get those features built-in.
